### PR TITLE
feat(core): 添加对自定义日期格式字符串的支持并集成 Rolldown 插件

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,11 @@
     "build": "tsup",
     "prepublishOnly": "npm run build"
   },
-  "dependencies": {
-  },
   "devDependencies": {
     "@types/node": "^22.14.1",
-    "tsup": "^8.4.0",
+    "rolldown": "^1",
     "rollup": "^3",
+    "tsup": "^8.4.0",
     "typescript": "^4.9.5",
     "vite": "^4",
     "webpack": "^5",
@@ -66,5 +65,14 @@
     "README.md",
     "README.zh-CN.md"
   ],
-  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"
+  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  },
+  "peerDependencies": {
+    "dayjs": "^1.11.21",
+    "es-toolkit": "^1.49.0"
+  }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,14 +1,16 @@
-import { getPackageVersion, defaultFormatDate } from './shared/utils';
-import { VersionInjectorOptions } from './types';
+import {defaultFormatDate, getPackageVersion} from './shared/utils';
+import type {VersionInjectorOptions} from './types';
+import {isString} from "es-toolkit/compat";
+import dayjs from "dayjs";
 
 export function createVersionInjector(options: VersionInjectorOptions = {}) {
-  const { version, name } =
-    options.version && options.name ? options : getPackageVersion();
-  const buildTime = (options.formatDate ?? defaultFormatDate)(new Date());
+    const {version, name} = options.version && options.name ? options : getPackageVersion();
 
-  const metaTag = `<meta name="version" content="${version}">\n<meta name="project" content="${name}">\n`;
+    const buildTime = isString(options.formatDate) ? dayjs(new Date()).format(options.formatDate) : (options.formatDate ?? defaultFormatDate)(new Date());
 
-  const logScript = `
+    const metaTag = `<meta name="version" content="${version}">\n<meta name="project" content="${name}">\n`;
+
+    const logScript = `
 <script data-injected="unplugin-version-injector">
   (function () {
     var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -23,18 +25,18 @@ export function createVersionInjector(options: VersionInjectorOptions = {}) {
   })();
 </script>`;
 
-  return function processHtml(html: string): string {
-    if (!html.includes('<meta name="version"')) {
-      html = html.replace(/<head>/i, `<head>\n  ${metaTag}`);
-    }
+    return function processHtml(html: string): string {
+        if (!html.includes('<meta name="version"')) {
+            html = html.replace(/<head>/i, `<head>\n  ${metaTag}`);
+        }
 
-    if (
-      options.log !== false &&
-      !html.includes('data-injected="unplugin-version-injector"')
-    ) {
-      html = html.replace(/<\/body>/i, `  ${logScript}\n</body>`);
-    }
+        if (
+            options.log !== false &&
+            !html.includes('data-injected="unplugin-version-injector"')
+        ) {
+            html = html.replace(/<\/body>/i, `  ${logScript}\n</body>`);
+        }
 
-    return html;
-  };
+        return html;
+    };
 }

--- a/src/rolldown.ts
+++ b/src/rolldown.ts
@@ -1,0 +1,23 @@
+import type {Plugin} from 'rolldown';
+import {createVersionInjector} from './core';
+import type {VersionInjectorOptions} from './types';
+
+export default function versionInjectorPlugin(options: VersionInjectorOptions = {}): Plugin {
+    const shouldInject = options.log !== false;
+    if (!shouldInject) {
+        return {name: 'unplugin-version-injector'};
+    }
+
+    const processHtml = createVersionInjector(options);
+
+    return {
+        name: 'unplugin-version-injector',
+        generateBundle(_, bundle) {
+            for (const file of Object.values(bundle)) {
+                if (file.type === 'asset' && file.fileName.endsWith('.html')) {
+                    file.source = processHtml(file.source as string);
+                }
+            }
+        },
+    };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
+export type DateFormatter = (date: Date) => string;
+
 export interface VersionInjectorOptions {
-  version?: string;  // 用户手动传递的版本号
-  name?: string;     // 用户手动传递的包名
-  log?: boolean; // 是否打印日志
-  formatDate?: (date: Date) => string; // 自定义 build time 格式化
+    version?: string;  // 用户手动传递的版本号
+    name?: string;     // 用户手动传递的包名
+    log?: boolean; // 是否打印日志
+    formatDate?: string | DateFormatter; // 自定义 build time 格式化
 }

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from 'vite';
 import { createVersionInjector } from './core';
+import type {VersionInjectorOptions} from "./types";
 
-export default function versionInjectorPlugin(options = {}): Plugin {
+export default function versionInjectorPlugin(options:VersionInjectorOptions = {}): Plugin {
   const inject = createVersionInjector(options);
 
   return {

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -1,7 +1,8 @@
 import type { Compiler } from 'webpack';
 import { createVersionInjector } from './core';
+import type {VersionInjectorOptions} from "./types";
 
-export default function versionInjectorPlugin(options = {}) {
+export default function versionInjectorPlugin(options:VersionInjectorOptions = {}) {
   const inject = createVersionInjector(options);
 
   return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
       "esModuleInterop": true,
       "skipLibCheck": true,
       "declaration": true, 
-      "outDir": "dist"
+      "outDir": "dist",
+      "jsx": "react"
     },
     "include": ["src"]
   }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -33,5 +33,16 @@ export default defineConfig([
     splitting: false,
     shims: false,
     treeshake: true,
+  },
+  {
+    entry: ['src/rolldown.ts'],
+    outDir: 'dist',
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: false,
+    platform: 'node',
+    splitting: false,
+    shims: false,
+    treeshake: true,
   }
 ]);


### PR DESCRIPTION
- 添加对自定义日期格式字符串的支持，允许传入 dayjs 格式化字符串
- 集成 Rolldown 构建工具插件支持
- 添加 es-toolkit 和 dayjs 作为对等依赖
- 更新构建配置以支持多种打包格式
- 优化代码格式和类型定义
- 添加对 JSX 支持的 TypeScript 配置
- 更新包管理器配置和依赖声明